### PR TITLE
Add replace section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "php-http/message": "^1.0",
         "php-http/guzzle6-adapter": "^1.0"
     },
+    "replace": {
+        "graphaware/neo4j-php-client": "^4.8"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
This will allow anyone to install this package no matter if the dependencies specify the graphaware package or not. 